### PR TITLE
More gracefully handle unexpected errors in listener, unit test mock class shouldn't generate unexpected errors.

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -207,6 +207,8 @@ class AudioConsumer(threading.Thread):
                         "Your device is not registered yet. To start pairing, "
                         "login at cerberus.mycroft.ai")
                 utterances.append("pair my device")
+            except Exception as e:
+                logger.error("Unexpected exception: {0}".format(e))
             else:
                 logger.debug("STT: " + text)
                 if text.strip() != '':

--- a/test/client/audio_consumer_test.py
+++ b/test/client/audio_consumer_test.py
@@ -19,6 +19,7 @@
 import unittest
 from Queue import Queue
 
+import speech_recognition
 from os.path import dirname, join
 from speech_recognition import WavFile, AudioData
 
@@ -35,7 +36,10 @@ class MockRecognizer(object):
         self.transcriptions = []
 
     def recognize_google(self, audio, key=None, language=None, show_all=False):
-        return self.transcriptions.pop(0)
+        if len(self.transcriptions) > 0:
+            return self.transcriptions.pop(0)
+        else:
+            raise speech_recognition.UnknownValueError()
 
     def set_transcriptions(self, transcriptions):
         self.transcriptions = transcriptions


### PR DESCRIPTION
Rebased
